### PR TITLE
Handle server shutdown.

### DIFF
--- a/comm.py
+++ b/comm.py
@@ -7,6 +7,7 @@ class Message(Enum):
     NAME_OK = auto()
     NAME_TOO_LONG = auto()
     NAME_USED = auto()
+    SERVER_SHUTDOWN = auto()
 
 # Sends the data in 'buffer' to 'socket'
 def send_data(socket, buffer):
@@ -39,5 +40,5 @@ def size_as_bytes(buffer):
     return size.encode()
 
 # 'buffer' is expected to be an array of bytes that can be decoded to a numeric string
-def size_as_int(buffer):
+def to_int(buffer):
     return int(buffer.decode())

--- a/game.py
+++ b/game.py
@@ -272,6 +272,7 @@ class Game():
         self.players = []
         self.camera = Camera(500, 500)
         self.pellets = RandomPellets(25)
+        self.running = True
         self.bounds = {
             'left': 0,
             'right': BOARD[0],
@@ -317,7 +318,7 @@ class Game():
 
     def game_loop(self):
         clock = Clock()
-        while True:
+        while self.running:
             pos = self.pellets.getPositions()
             for player in self.players:
                 snake = player.snake

--- a/server.py
+++ b/server.py
@@ -26,16 +26,20 @@ class Server():
 
     def listen(self):
         while True:
-            socket, addr = self.s.accept()
+            sock, addr = self.s.accept()
+            if not self.game.running:
+                sock.shutdown(socket.SHUT_RDWR)
+                sock.close()
+                self.s.close()
+                break
             print("Connected to:", addr)
-
-            Thread(target=self.player_handler, args=(socket,)).start()
+            Thread(target=self.player_handler, args=(sock,)).start()
 
     def receive_name(self, player):
         while True:
             # Receive name input or quit signal
             input_size_as_bytes = comm.receive_data(player.socket, comm.MSG_LEN)
-            input_size = comm.size_as_int(input_size_as_bytes)
+            input_size = comm.to_int(input_size_as_bytes)
             input = pickle.loads(comm.receive_data(player.socket, input_size))
 
             # Client quit during name selection
@@ -74,12 +78,17 @@ class Server():
                 comm.send_data(player.socket, max_length)
 
     def receive_input(self, player):
-        while True:
-            input_size_as_bytes = comm.receive_data(player.socket, comm.MSG_LEN)
-            input_size = comm.size_as_int(input_size_as_bytes)
-            input = pickle.loads(comm.receive_data(player.socket, input_size))
+        while self.game.running:
+            try:
+                input_size_as_bytes = comm.receive_data(player.socket, comm.MSG_LEN)
+                input_size = comm.to_int(input_size_as_bytes)
+                input = pickle.loads(comm.receive_data(player.socket, input_size))
+            except:
+                continue
             if input == comm.Message.QUIT:
                 self.game.remove_player(player)
+                player.socket.shutdown(socket.SHUT_RDWR)
+                player.socket.close()
                 break
             player.snake.change_direction(input)
 
@@ -99,10 +108,37 @@ class Server():
         comm.send_data(player.socket, size)
         comm.send_data(player.socket, game_data_serialized)
 
+    # Before exiting, send a message to all players notifying them that the server will shutdown
+    # Close each player's socket connection
+    # Connect a dummy socket to stop the listening thread from hanging on the socket.accept() call
+    def on_exit(self):
+        self.game.running = False
+        shutdown_msg = pickle.dumps(comm.Message.SERVER_SHUTDOWN)
+        shutdown_msg_length = comm.size_as_bytes(shutdown_msg)
+        for player in self.game.players:
+            comm.send_data(player.socket, shutdown_msg_length)
+            comm.send_data(player.socket, shutdown_msg)
+            player.socket.shutdown(socket.SHUT_RDWR)
+            player.socket.close()
+
+        terminator_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        terminator_socket.connect((self.host, self.port))
+        terminator_socket.shutdown(socket.SHUT_RDWR)
+        terminator_socket.close()
+        
+    # Prompt the user to shutdown the server by typing 'exit'
+    def listen_exit(self):
+        while self.game.running:
+            print('Enter \'exit\' to shutdown server')
+            user_input = input()
+            if user_input.lower() == 'exit':
+                self.on_exit()
+
 def main():
     server = Server()
     server.start()
-    server.listen()
+    Thread(target=server.listen).start()
+    server.listen_exit()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Shutdown is handled by closing all client connections from the server side. The server sends a final message indicating that it will shut down, which the clients use to exit the game. Shutdown is only handled gracefully if the user types 'exit' in the command line. If the user kills the server program using the 'X' icon or through Task Manager, it will crash upon exiting. It would've been better to handle those cases gracefully as well, but upon reading up on it, it seems that there's no way to do it a cross compatible way. I didn't find it worth the hassle.